### PR TITLE
Update Discord invite link to udArp6jR2Y

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 \_| |_/\__,_|\___|_|\_\___|_|  |___/<pre></div><div class="links"><pre>
 ┌─(root@noco)-[stuff]
 └─# ls
-about <a href="https://nocohackers.com/game">bun_run_the_game</a> discord  <a href="https://github.com/NoCoHackers/NoCoHackers.github.io/tree/main">event_repo</a> <a href="https://docs.google.com/forms/d/1v1UYgEOCzjJvIIrUeBE45Nti5Ho2tCzIuiuAjBQunuQ/viewform?edit_requested=true#response=ACYDBNjiVo_xmaGpfEASvWqw2Eax4KdPEd34CjFgF-cZA1mAT6Rxq4wcBa38m39Fw-e3xCQ">talk_submission</a> <a href="https://www.meetup.com/noco-hackers/">upcoming_events</a>
+about <a href="https://nocohackers.com/game">bun_run_the_game</a> <a href="https://discord.gg/udArp6jR2Y">discord</a>  <a href="https://github.com/NoCoHackers/NoCoHackers.github.io/tree/main">event_repo</a> <a href="https://docs.google.com/forms/d/1v1UYgEOCzjJvIIrUeBE45Nti5Ho2tCzIuiuAjBQunuQ/viewform?edit_requested=true#response=ACYDBNjiVo_xmaGpfEASvWqw2Eax4KdPEd34CjFgF-cZA1mAT6Rxq4wcBa38m39Fw-e3xCQ">talk_submission</a> <a href="https://www.meetup.com/noco-hackers/">upcoming_events</a>
 ┌─(root@noco)-[stuff]
 └─# cat discord
 $9$J-ZUHzF/t0IDi/t0OSyvWL7Vwg4ZqmTgo5QF6u0vWL7wgiHmQ39go5Q3/puVbsYaGQznCpBdbjqmfF3puOIEy


### PR DESCRIPTION
Updates the Discord invite link in the navigation menu to use the new invite code `udArp6jR2Y`.

Fixes #4
